### PR TITLE
Add use_cache argument to load dataset function (forwarded to TSDB)

### DIFF
--- a/benchpots/datasets/physionet_2012.py
+++ b/benchpots/datasets/physionet_2012.py
@@ -21,6 +21,7 @@ def preprocess_physionet2012(
     rate,
     pattern: str = "point",
     features: list = None,
+    use_cache: bool = True,
     **kwargs,
 ) -> dict:
     """Load and preprocess the dataset PhysionNet2012.
@@ -66,7 +67,7 @@ def preprocess_physionet2012(
     assert 0 <= rate < 1, f"rate must be in [0, 1), but got {rate}"
 
     # read the raw data
-    data = tsdb.load("physionet_2012")
+    data = tsdb.load("physionet_2012", use_cache)
     all_features = set(data["set-a"].columns)
     data["static_features"].remove("ICUType")  # keep ICUType for now
 


### PR DESCRIPTION
When I want to hard reload physionet2012_dataset from PyPOTS, it is impossible directly without manually removing directory, so I added use_cache to preprocess_physionet2012 function. 