### PR TITLE
Fix error "This filename has already been used" from PyPI when releasing v0.3.1

### DIFF
--- a/.github/workflows/publish_to_PyPI.yml
+++ b/.github/workflows/publish_to_PyPI.yml
@@ -47,7 +47,7 @@ jobs:
         python -m build
 
     - name: Publish the new package to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.8.6
+      uses: pypa/gh-action-pypi-publish@v1.12.4
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/benchpots/version.py
+++ b/benchpots/version.py
@@ -22,4 +22,4 @@
 #
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
-__version__ = "0.3.1"
+__version__ = "0.3.2"


### PR DESCRIPTION
Met with error "This filename has already been used" from PyPI when uploading v0.3.1, refer to https://github.com/WenjieDu/BenchPOTS/actions/runs/13162996392/job/36736420534

I try to update the publishing action pypa/gh-action-pypi-publish version, also deprecate v0.3.1 and use v0.3.2