### PR TITLE
Reverse the order of forecasting truncating and artificial missing values addition

### DIFF
--- a/benchpots/datasets/__init__.py
+++ b/benchpots/datasets/__init__.py
@@ -1,6 +1,4 @@
-"""
-
-"""
+""" """
 
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause

--- a/benchpots/datasets/beijing_multisite_air_quality.py
+++ b/benchpots/datasets/beijing_multisite_air_quality.py
@@ -6,6 +6,8 @@ Preprocessing func for the dataset Beijing Multi-site Air Quality.
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause
 
+from typing import Optional
+
 import pandas as pd
 import tsdb
 from sklearn.preprocessing import StandardScaler
@@ -20,6 +22,7 @@ def preprocess_beijing_air_quality(
     rate,
     n_steps,
     pattern: str = "point",
+    random_state: Optional[int] = None,
     task_type: str = "imputation",
     n_pred_steps: int = 1,
     forecast_feature_indices=None,
@@ -39,6 +42,10 @@ def preprocess_beijing_air_quality(
     pattern:
         The missing pattern to apply to the dataset.
         Must be one of ['point', 'subseq', 'block'].
+
+    random_state:
+        Controls the randomness of missingness generation.
+        Pass an int for reproducible missingness masks across runs.
 
     task_type:
         Task type for postprocessing. Supported values are
@@ -135,6 +142,9 @@ def preprocess_beijing_air_quality(
     }
 
     if rate > 0:
+        if random_state is not None and "random_state" not in kwargs:
+            kwargs["random_state"] = random_state
+
         # hold out ground truth in the original data for evaluation
         train_X_ori = train_X
         val_X_ori = val_X

--- a/benchpots/datasets/beijing_multisite_air_quality.py
+++ b/benchpots/datasets/beijing_multisite_air_quality.py
@@ -6,7 +6,7 @@ Preprocessing func for the dataset Beijing Multi-site Air Quality.
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause
 
-from typing import Optional
+from typing import Any, Optional, Sequence, Union
 
 import pandas as pd
 import tsdb
@@ -19,14 +19,14 @@ from ..utils.task_type import convert_processed_dataset_by_task_type
 
 
 def preprocess_beijing_air_quality(
-    rate,
-    n_steps,
+    rate: float,
+    n_steps: int,
     pattern: str = "point",
     random_state: Optional[int] = None,
     task_type: str = "imputation",
     n_pred_steps: int = 1,
-    forecast_feature_indices=None,
-    **kwargs,
+    forecast_feature_indices: Optional[Union[int, Sequence[int]]] = None,
+    **kwargs: Any,
 ) -> dict:
     """Load and preprocess the dataset Beijing Multi-site Air Quality.
 
@@ -78,32 +78,23 @@ def preprocess_beijing_air_quality(
         current_df = df[df["station"] == station]
         logger.info(f"Current dataframe shape: {current_df.shape}")
 
-        current_df["date_time"] = pd.to_datetime(
-            current_df[["year", "month", "day", "hour"]]
-        )
+        current_df["date_time"] = pd.to_datetime(current_df[["year", "month", "day", "hour"]])
         station_name_collector.append(current_df.loc[0, "station"])
         # remove duplicated date info and wind direction, which is a categorical col
-        current_df = current_df.drop(
-            ["year", "month", "day", "hour", "wd", "No", "station"], axis=1
-        )
+        current_df = current_df.drop(["year", "month", "day", "hour", "wd", "No", "station"], axis=1)
         df_collector.append(current_df)
 
-    logger.info(
-        f"There are total {len(station_name_collector)} stations, they are {station_name_collector}"
-    )
+    logger.info(f"There are total {len(station_name_collector)} stations, they are {station_name_collector}")
     date_time = df_collector[0]["date_time"]
     df_collector = [i.drop("date_time", axis=1) for i in df_collector]
     df = pd.concat(df_collector, axis=1)
     feature_names = [
-        station + "_" + feature
-        for station in station_name_collector
-        for feature in df_collector[0].columns
+        station + "_" + feature for station in station_name_collector for feature in df_collector[0].columns
     ]
     feature_num = len(feature_names)
     df.columns = feature_names
     logger.info(
-        f"Original df missing rate: "
-        f"{(df[feature_names].isna().sum().sum() / (df.shape[0] * feature_num)):.3f}"
+        f"Original df missing rate: " f"{(df[feature_names].isna().sum().sum() / (df.shape[0] * feature_num)):.3f}"
     )
 
     df["date_time"] = date_time
@@ -141,21 +132,28 @@ def preprocess_beijing_air_quality(
         "test_X": test_X,
     }
 
+    processed_dataset = convert_processed_dataset_by_task_type(
+        processed_dataset,
+        task_type=task_type,
+        n_pred_steps=n_pred_steps,
+        forecast_feature_indices=forecast_feature_indices,
+    )
+
     if rate > 0:
         if random_state is not None and "random_state" not in kwargs:
             kwargs["random_state"] = random_state
 
         # hold out ground truth in the original data for evaluation
-        train_X_ori = train_X
-        val_X_ori = val_X
-        test_X_ori = test_X
+        train_X_ori = processed_dataset["train_X"]
+        val_X_ori = processed_dataset["val_X"]
+        test_X_ori = processed_dataset["test_X"]
 
         # mask values in the train set to keep the same with below validation and test sets
-        train_X = create_missingness(train_X, rate, pattern, **kwargs)
+        train_X = create_missingness(processed_dataset["train_X"], rate, pattern, **kwargs)
         # mask values in the validation set as ground truth
-        val_X = create_missingness(val_X, rate, pattern, **kwargs)
+        val_X = create_missingness(processed_dataset["val_X"], rate, pattern, **kwargs)
         # mask values in the test set as ground truth
-        test_X = create_missingness(test_X, rate, pattern, **kwargs)
+        test_X = create_missingness(processed_dataset["test_X"], rate, pattern, **kwargs)
 
         processed_dataset["train_X"] = train_X
         processed_dataset["train_X_ori"] = train_X_ori
@@ -167,16 +165,5 @@ def preprocess_beijing_air_quality(
         processed_dataset["test_X_ori"] = test_X_ori
     else:
         logger.warning("rate is 0, no missing values are artificially added.")
-
-    processed_dataset = convert_processed_dataset_by_task_type(
-        processed_dataset,
-        task_type=task_type,
-        n_pred_steps=n_pred_steps,
-        forecast_feature_indices=forecast_feature_indices,
-    )
-    train_X = processed_dataset["train_X"]
-    val_X = processed_dataset["val_X"]
-    test_X = processed_dataset["test_X"]
-
-    print_final_dataset_info(train_X, val_X, test_X)
+    print_final_dataset_info(processed_dataset)
     return processed_dataset

--- a/benchpots/datasets/electricity_load_diagrams.py
+++ b/benchpots/datasets/electricity_load_diagrams.py
@@ -6,6 +6,8 @@ Preprocessing func for the dataset Electricity Load Diagrams.
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause
 
+from typing import Optional
+
 import pandas as pd
 import tsdb
 from sklearn.preprocessing import StandardScaler
@@ -20,6 +22,7 @@ def preprocess_electricity_load_diagrams(
     rate,
     n_steps,
     pattern: str = "point",
+    random_state: Optional[int] = None,
     task_type: str = "imputation",
     n_pred_steps: int = 1,
     forecast_feature_indices=None,
@@ -39,6 +42,10 @@ def preprocess_electricity_load_diagrams(
     pattern:
         The missing pattern to apply to the dataset.
         Must be one of ['point', 'subseq', 'block'].
+
+    random_state:
+        Controls the randomness of missingness generation.
+        Pass an int for reproducible missingness masks across runs.
 
     task_type:
         Task type for postprocessing. Supported values are
@@ -103,6 +110,9 @@ def preprocess_electricity_load_diagrams(
     }
 
     if rate > 0:
+        if random_state is not None and "random_state" not in kwargs:
+            kwargs["random_state"] = random_state
+
         # hold out ground truth in the original data for evaluation
         train_X_ori = train_X
         val_X_ori = val_X

--- a/benchpots/datasets/electricity_load_diagrams.py
+++ b/benchpots/datasets/electricity_load_diagrams.py
@@ -6,7 +6,7 @@ Preprocessing func for the dataset Electricity Load Diagrams.
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause
 
-from typing import Optional
+from typing import Any, Optional, Sequence, Union
 
 import pandas as pd
 import tsdb
@@ -19,14 +19,14 @@ from ..utils.task_type import convert_processed_dataset_by_task_type
 
 
 def preprocess_electricity_load_diagrams(
-    rate,
-    n_steps,
+    rate: float,
+    n_steps: int,
     pattern: str = "point",
     random_state: Optional[int] = None,
     task_type: str = "imputation",
     n_pred_steps: int = 1,
-    forecast_feature_indices=None,
-    **kwargs,
+    forecast_feature_indices: Optional[Union[int, Sequence[int]]] = None,
+    **kwargs: Any,
 ) -> dict:
     """Load and preprocess the dataset Electricity Load Diagrams.
 
@@ -76,9 +76,7 @@ def preprocess_electricity_load_diagrams(
     unique_months = df["datetime"].dt.to_period("M").unique()
     selected_as_test = unique_months[:10]  # select first 10 months as test set
     logger.info(f"months selected as test set are {selected_as_test}")
-    selected_as_val = unique_months[
-        10:20
-    ]  # select the 11th - the 20th months as val set
+    selected_as_val = unique_months[10:20]  # select the 11th - the 20th months as val set
     logger.info(f"months selected as val set are {selected_as_val}")
     selected_as_train = unique_months[20:]  # use left months as train set
     logger.info(f"months selected as train set are {selected_as_train}")
@@ -109,21 +107,28 @@ def preprocess_electricity_load_diagrams(
         "test_X": test_X,
     }
 
+    processed_dataset = convert_processed_dataset_by_task_type(
+        processed_dataset,
+        task_type=task_type,
+        n_pred_steps=n_pred_steps,
+        forecast_feature_indices=forecast_feature_indices,
+    )
+
     if rate > 0:
         if random_state is not None and "random_state" not in kwargs:
             kwargs["random_state"] = random_state
 
         # hold out ground truth in the original data for evaluation
-        train_X_ori = train_X
-        val_X_ori = val_X
-        test_X_ori = test_X
+        train_X_ori = processed_dataset["train_X"]
+        val_X_ori = processed_dataset["val_X"]
+        test_X_ori = processed_dataset["test_X"]
 
         # mask values in the train set to keep the same with below validation and test sets
-        train_X = create_missingness(train_X, rate, pattern, **kwargs)
+        train_X = create_missingness(processed_dataset["train_X"], rate, pattern, **kwargs)
         # mask values in the validation set as ground truth
-        val_X = create_missingness(val_X, rate, pattern, **kwargs)
+        val_X = create_missingness(processed_dataset["val_X"], rate, pattern, **kwargs)
         # mask values in the test set as ground truth
-        test_X = create_missingness(test_X, rate, pattern, **kwargs)
+        test_X = create_missingness(processed_dataset["test_X"], rate, pattern, **kwargs)
 
         processed_dataset["train_X"] = train_X
         processed_dataset["train_X_ori"] = train_X_ori
@@ -135,16 +140,5 @@ def preprocess_electricity_load_diagrams(
         processed_dataset["test_X_ori"] = test_X_ori
     else:
         logger.warning("rate is 0, no missing values are artificially added.")
-
-    processed_dataset = convert_processed_dataset_by_task_type(
-        processed_dataset,
-        task_type=task_type,
-        n_pred_steps=n_pred_steps,
-        forecast_feature_indices=forecast_feature_indices,
-    )
-    train_X = processed_dataset["train_X"]
-    val_X = processed_dataset["val_X"]
-    test_X = processed_dataset["test_X"]
-
-    print_final_dataset_info(train_X, val_X, test_X)
+    print_final_dataset_info(processed_dataset)
     return processed_dataset

--- a/benchpots/datasets/electricity_transformer_temperature.py
+++ b/benchpots/datasets/electricity_transformer_temperature.py
@@ -6,6 +6,8 @@ Preprocessing func for the dataset ETT (Electricity Transformer Temperature).
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause
 
+from typing import Optional
+
 import pandas as pd
 import tsdb
 from sklearn.preprocessing import StandardScaler
@@ -21,6 +23,7 @@ def preprocess_ett(
     rate,
     n_steps,
     pattern: str = "point",
+    random_state: Optional[int] = None,
     task_type: str = "imputation",
     n_pred_steps: int = 1,
     forecast_feature_indices=None,
@@ -44,6 +47,10 @@ def preprocess_ett(
     pattern:
         The missing pattern to apply to the dataset.
         Must be one of ['point', 'subseq', 'block'].
+
+    random_state:
+        Controls the randomness of missingness generation.
+        Pass an int for reproducible missingness masks across runs.
 
     task_type:
         Task type for postprocessing. Supported values are
@@ -110,6 +117,9 @@ def preprocess_ett(
     }
 
     if rate > 0:
+        if random_state is not None and "random_state" not in kwargs:
+            kwargs["random_state"] = random_state
+
         # hold out ground truth in the original data for evaluation
         train_X_ori = train_X
         val_X_ori = val_X

--- a/benchpots/datasets/electricity_transformer_temperature.py
+++ b/benchpots/datasets/electricity_transformer_temperature.py
@@ -6,7 +6,7 @@ Preprocessing func for the dataset ETT (Electricity Transformer Temperature).
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause
 
-from typing import Optional
+from typing import Any, Optional, Sequence, Union
 
 import pandas as pd
 import tsdb
@@ -19,15 +19,15 @@ from ..utils.task_type import convert_processed_dataset_by_task_type
 
 
 def preprocess_ett(
-    subset,
-    rate,
-    n_steps,
+    subset: str,
+    rate: float,
+    n_steps: int,
     pattern: str = "point",
     random_state: Optional[int] = None,
     task_type: str = "imputation",
     n_pred_steps: int = 1,
-    forecast_feature_indices=None,
-    **kwargs,
+    forecast_feature_indices: Optional[Union[int, Sequence[int]]] = None,
+    **kwargs: Any,
 ) -> dict:
     """Load and preprocess the dataset ETT.
 
@@ -69,9 +69,7 @@ def preprocess_ett(
     """
 
     all_subset_names = ["ETTm1", "ETTm2", "ETTh1", "ETTh2"]
-    assert (
-        subset in all_subset_names
-    ), f"subset_name should be one of {all_subset_names}, but got {subset}"
+    assert subset in all_subset_names, f"subset_name should be one of {all_subset_names}, but got {subset}"
     assert 0 <= rate < 1, f"rate must be in [0, 1), but got {rate}"
     assert n_steps > 0, f"sample_n_steps must be larger than 0, but got {n_steps}"
 
@@ -116,21 +114,28 @@ def preprocess_ett(
         "test_X": test_X,
     }
 
+    processed_dataset = convert_processed_dataset_by_task_type(
+        processed_dataset,
+        task_type=task_type,
+        n_pred_steps=n_pred_steps,
+        forecast_feature_indices=forecast_feature_indices,
+    )
+
     if rate > 0:
         if random_state is not None and "random_state" not in kwargs:
             kwargs["random_state"] = random_state
 
         # hold out ground truth in the original data for evaluation
-        train_X_ori = train_X
-        val_X_ori = val_X
-        test_X_ori = test_X
+        train_X_ori = processed_dataset["train_X"]
+        val_X_ori = processed_dataset["val_X"]
+        test_X_ori = processed_dataset["test_X"]
 
         # mask values in the train set to keep the same with below validation and test sets
-        train_X = create_missingness(train_X, rate, pattern, **kwargs)
+        train_X = create_missingness(processed_dataset["train_X"], rate, pattern, **kwargs)
         # mask values in the validation set as ground truth
-        val_X = create_missingness(val_X, rate, pattern, **kwargs)
+        val_X = create_missingness(processed_dataset["val_X"], rate, pattern, **kwargs)
         # mask values in the test set as ground truth
-        test_X = create_missingness(test_X, rate, pattern, **kwargs)
+        test_X = create_missingness(processed_dataset["test_X"], rate, pattern, **kwargs)
 
         processed_dataset["train_X"] = train_X
         processed_dataset["train_X_ori"] = train_X_ori
@@ -143,16 +148,5 @@ def preprocess_ett(
         processed_dataset["test_X_ori"] = test_X_ori
     else:
         logger.warning("rate is 0, no missing values are artificially added.")
-
-    processed_dataset = convert_processed_dataset_by_task_type(
-        processed_dataset,
-        task_type=task_type,
-        n_pred_steps=n_pred_steps,
-        forecast_feature_indices=forecast_feature_indices,
-    )
-    train_X = processed_dataset["train_X"]
-    val_X = processed_dataset["val_X"]
-    test_X = processed_dataset["test_X"]
-
-    print_final_dataset_info(train_X, val_X, test_X)
+    print_final_dataset_info(processed_dataset)
     return processed_dataset

--- a/benchpots/datasets/italy_air_quality.py
+++ b/benchpots/datasets/italy_air_quality.py
@@ -6,7 +6,7 @@ Preprocessing func for the dataset Italy Air Quality.
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause
 
-from typing import Optional
+from typing import Any, Optional, Sequence, Union
 
 import tsdb
 from sklearn.preprocessing import StandardScaler
@@ -18,14 +18,14 @@ from ..utils.task_type import convert_processed_dataset_by_task_type
 
 
 def preprocess_italy_air_quality(
-    rate,
-    n_steps,
+    rate: float,
+    n_steps: int,
     pattern: str = "point",
     random_state: Optional[int] = None,
     task_type: str = "imputation",
     n_pred_steps: int = 1,
-    forecast_feature_indices=None,
-    **kwargs,
+    forecast_feature_indices: Optional[Union[int, Sequence[int]]] = None,
+    **kwargs: Any,
 ) -> dict:
     """Load and preprocess the dataset Italy Air Quality.
 
@@ -62,6 +62,7 @@ def preprocess_italy_air_quality(
         A dictionary containing the processed Italy Air Quality.
     """
 
+    assert 0 <= rate < 1, f"rate must be in [0, 1), but got {rate}"
     assert n_steps > 0, f"sample_n_steps must be larger than 0, but got {n_steps}"
 
     data = tsdb.load("italy_air_quality")
@@ -100,21 +101,28 @@ def preprocess_italy_air_quality(
         "test_X": test_X,
     }
 
+    processed_dataset = convert_processed_dataset_by_task_type(
+        processed_dataset,
+        task_type=task_type,
+        n_pred_steps=n_pred_steps,
+        forecast_feature_indices=forecast_feature_indices,
+    )
+
     if rate > 0:
         if random_state is not None and "random_state" not in kwargs:
             kwargs["random_state"] = random_state
 
         # hold out ground truth in the original data for evaluation
-        train_X_ori = train_X
-        val_X_ori = val_X
-        test_X_ori = test_X
+        train_X_ori = processed_dataset["train_X"]
+        val_X_ori = processed_dataset["val_X"]
+        test_X_ori = processed_dataset["test_X"]
 
         # mask values in the train set to keep the same with below validation and test sets
-        train_X = create_missingness(train_X, rate, pattern, **kwargs)
+        train_X = create_missingness(processed_dataset["train_X"], rate, pattern, **kwargs)
         # mask values in the validation set as ground truth
-        val_X = create_missingness(val_X, rate, pattern, **kwargs)
+        val_X = create_missingness(processed_dataset["val_X"], rate, pattern, **kwargs)
         # mask values in the test set as ground truth
-        test_X = create_missingness(test_X, rate, pattern, **kwargs)
+        test_X = create_missingness(processed_dataset["test_X"], rate, pattern, **kwargs)
 
         processed_dataset["train_X"] = train_X
         processed_dataset["train_X_ori"] = train_X_ori
@@ -126,16 +134,5 @@ def preprocess_italy_air_quality(
         processed_dataset["test_X_ori"] = test_X_ori
     else:
         logger.warning("rate is 0, no missing values are artificially added.")
-
-    processed_dataset = convert_processed_dataset_by_task_type(
-        processed_dataset,
-        task_type=task_type,
-        n_pred_steps=n_pred_steps,
-        forecast_feature_indices=forecast_feature_indices,
-    )
-    train_X = processed_dataset["train_X"]
-    val_X = processed_dataset["val_X"]
-    test_X = processed_dataset["test_X"]
-
-    print_final_dataset_info(train_X, val_X, test_X)
+    print_final_dataset_info(processed_dataset)
     return processed_dataset

--- a/benchpots/datasets/italy_air_quality.py
+++ b/benchpots/datasets/italy_air_quality.py
@@ -6,6 +6,8 @@ Preprocessing func for the dataset Italy Air Quality.
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause
 
+from typing import Optional
+
 import tsdb
 from sklearn.preprocessing import StandardScaler
 
@@ -19,6 +21,7 @@ def preprocess_italy_air_quality(
     rate,
     n_steps,
     pattern: str = "point",
+    random_state: Optional[int] = None,
     task_type: str = "imputation",
     n_pred_steps: int = 1,
     forecast_feature_indices=None,
@@ -38,6 +41,10 @@ def preprocess_italy_air_quality(
     pattern:
         The missing pattern to apply to the dataset.
         Must be one of ['point', 'subseq', 'block'].
+
+    random_state:
+        Controls the randomness of missingness generation.
+        Pass an int for reproducible missingness masks across runs.
 
     task_type:
         Task type for postprocessing. Supported values are
@@ -94,6 +101,9 @@ def preprocess_italy_air_quality(
     }
 
     if rate > 0:
+        if random_state is not None and "random_state" not in kwargs:
+            kwargs["random_state"] = random_state
+
         # hold out ground truth in the original data for evaluation
         train_X_ori = train_X
         val_X_ori = val_X

--- a/benchpots/datasets/nl_benchmarks.py
+++ b/benchpots/datasets/nl_benchmarks.py
@@ -6,12 +6,11 @@ Preprocessing func for nonlinear benchmarks.
 # Created by Sikai Zhang <matthew.szhang91@gmail.com>
 # License: BSD-3-Clause
 
-from typing import Optional
-
-import numpy as np
 import nonlinear_benchmarks
-from typing import Any, Optional, Sequence, Union
+import numpy as np
 from sklearn.preprocessing import StandardScaler
+from typing import Any, Optional, Sequence, Union
+from typing import Optional
 
 from ..utils.logging import logger, print_final_dataset_info
 from ..utils.missingness import create_missingness

--- a/benchpots/datasets/nl_benchmarks.py
+++ b/benchpots/datasets/nl_benchmarks.py
@@ -8,8 +8,9 @@ Preprocessing func for nonlinear benchmarks.
 
 from typing import Optional
 
-import nonlinear_benchmarks
 import numpy as np
+import nonlinear_benchmarks
+from typing import Any, Optional, Sequence, Union
 from sklearn.preprocessing import StandardScaler
 
 from ..utils.logging import logger, print_final_dataset_info
@@ -19,15 +20,15 @@ from ..utils.task_type import convert_processed_dataset_by_task_type
 
 
 def preprocess_nl_benchmarks(
-    dataset_name,
-    rate,
-    n_steps,
+    dataset_name: str,
+    rate: float,
+    n_steps: int,
     pattern: str = "point",
     random_state: Optional[int] = None,
     task_type: str = "imputation",
     n_pred_steps: int = 1,
-    forecast_feature_indices=None,
-    **kwargs,
+    forecast_feature_indices: Optional[Union[int, Sequence[int]]] = None,
+    **kwargs: Any,
 ) -> dict:
     """Load and preprocess the dataset from nonlinear benchmarks.
 
@@ -75,6 +76,7 @@ def preprocess_nl_benchmarks(
         A dictionary containing the processed nonlinear benchmark datasets.
     """
 
+    assert 0 <= rate < 1, f"rate must be in [0, 1), but got {rate}"
     assert n_steps > 0, f"sample_n_steps must be larger than 0, but got {n_steps}"
 
     if dataset_name == "EMPS":
@@ -151,21 +153,28 @@ def preprocess_nl_benchmarks(
         "test_X": test_X,
     }
 
+    processed_dataset = convert_processed_dataset_by_task_type(
+        processed_dataset,
+        task_type=task_type,
+        n_pred_steps=n_pred_steps,
+        forecast_feature_indices=forecast_feature_indices,
+    )
+
     if rate > 0:
         if random_state is not None and "random_state" not in kwargs:
             kwargs["random_state"] = random_state
 
         # hold out ground truth in the original data for evaluation
-        train_X_ori = train_X
-        val_X_ori = val_X
-        test_X_ori = test_X
+        train_X_ori = processed_dataset["train_X"]
+        val_X_ori = processed_dataset["val_X"]
+        test_X_ori = processed_dataset["test_X"]
 
         # mask values in the train set to keep the same with below validation and test sets
-        train_X = create_missingness(train_X, rate, pattern, **kwargs)
+        train_X = create_missingness(processed_dataset["train_X"], rate, pattern, **kwargs)
         # mask values in the validation set as ground truth
-        val_X = create_missingness(val_X, rate, pattern, **kwargs)
+        val_X = create_missingness(processed_dataset["val_X"], rate, pattern, **kwargs)
         # mask values in the test set as ground truth
-        test_X = create_missingness(test_X, rate, pattern, **kwargs)
+        test_X = create_missingness(processed_dataset["test_X"], rate, pattern, **kwargs)
 
         processed_dataset["train_X"] = train_X
         processed_dataset["train_X_ori"] = train_X_ori
@@ -177,16 +186,5 @@ def preprocess_nl_benchmarks(
         processed_dataset["test_X_ori"] = test_X_ori
     else:
         logger.warning("rate is 0, no missing values are artificially added.")
-
-    processed_dataset = convert_processed_dataset_by_task_type(
-        processed_dataset,
-        task_type=task_type,
-        n_pred_steps=n_pred_steps,
-        forecast_feature_indices=forecast_feature_indices,
-    )
-    train_X = processed_dataset["train_X"]
-    val_X = processed_dataset["val_X"]
-    test_X = processed_dataset["test_X"]
-
-    print_final_dataset_info(train_X, val_X, test_X)
+    print_final_dataset_info(processed_dataset)
     return processed_dataset

--- a/benchpots/datasets/nl_benchmarks.py
+++ b/benchpots/datasets/nl_benchmarks.py
@@ -10,7 +10,6 @@ import nonlinear_benchmarks
 import numpy as np
 from sklearn.preprocessing import StandardScaler
 from typing import Any, Optional, Sequence, Union
-from typing import Optional
 
 from ..utils.logging import logger, print_final_dataset_info
 from ..utils.missingness import create_missingness

--- a/benchpots/datasets/nl_benchmarks.py
+++ b/benchpots/datasets/nl_benchmarks.py
@@ -6,6 +6,8 @@ Preprocessing func for nonlinear benchmarks.
 # Created by Sikai Zhang <matthew.szhang91@gmail.com>
 # License: BSD-3-Clause
 
+from typing import Optional
+
 import nonlinear_benchmarks
 import numpy as np
 from sklearn.preprocessing import StandardScaler
@@ -21,6 +23,7 @@ def preprocess_nl_benchmarks(
     rate,
     n_steps,
     pattern: str = "point",
+    random_state: Optional[int] = None,
     task_type: str = "imputation",
     n_pred_steps: int = 1,
     forecast_feature_indices=None,
@@ -51,6 +54,10 @@ def preprocess_nl_benchmarks(
     pattern:
         The missing pattern to apply to the dataset.
         Must be one of ['point', 'subseq', 'block'].
+
+    random_state:
+        Controls the randomness of missingness generation.
+        Pass an int for reproducible missingness masks across runs.
 
     task_type:
         Task type for postprocessing. Supported values are
@@ -145,6 +152,9 @@ def preprocess_nl_benchmarks(
     }
 
     if rate > 0:
+        if random_state is not None and "random_state" not in kwargs:
+            kwargs["random_state"] = random_state
+
         # hold out ground truth in the original data for evaluation
         train_X_ori = train_X
         val_X_ori = val_X

--- a/benchpots/datasets/pems_traffic.py
+++ b/benchpots/datasets/pems_traffic.py
@@ -6,6 +6,8 @@ Preprocessing func for the dataset PeMS traffic.
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause
 
+from typing import Optional
+
 import pandas as pd
 import tsdb
 from sklearn.preprocessing import StandardScaler
@@ -20,6 +22,7 @@ def preprocess_pems_traffic(
     rate,
     n_steps,
     pattern: str = "point",
+    random_state: Optional[int] = None,
     task_type: str = "imputation",
     n_pred_steps: int = 1,
     forecast_feature_indices=None,
@@ -39,6 +42,10 @@ def preprocess_pems_traffic(
     pattern:
         The missing pattern to apply to the dataset.
         Must be one of ['point', 'subseq', 'block'].
+
+    random_state:
+        Controls the randomness of missingness generation.
+        Pass an int for reproducible missingness masks across runs.
 
     task_type:
         Task type for postprocessing. Supported values are
@@ -105,6 +112,9 @@ def preprocess_pems_traffic(
     }
 
     if rate > 0:
+        if random_state is not None and "random_state" not in kwargs:
+            kwargs["random_state"] = random_state
+
         # hold out ground truth in the original data for evaluation
         train_X_ori = train_X
         val_X_ori = val_X

--- a/benchpots/datasets/pems_traffic.py
+++ b/benchpots/datasets/pems_traffic.py
@@ -6,7 +6,7 @@ Preprocessing func for the dataset PeMS traffic.
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause
 
-from typing import Optional
+from typing import Any, Optional, Sequence, Union
 
 import pandas as pd
 import tsdb
@@ -19,14 +19,14 @@ from ..utils.task_type import convert_processed_dataset_by_task_type
 
 
 def preprocess_pems_traffic(
-    rate,
-    n_steps,
+    rate: float,
+    n_steps: int,
     pattern: str = "point",
     random_state: Optional[int] = None,
     task_type: str = "imputation",
     n_pred_steps: int = 1,
-    forecast_feature_indices=None,
-    **kwargs,
+    forecast_feature_indices: Optional[Union[int, Sequence[int]]] = None,
+    **kwargs: Any,
 ) -> dict:
     """Load and preprocess the dataset PeMS traffic.
 
@@ -111,21 +111,28 @@ def preprocess_pems_traffic(
         "test_X": test_X,
     }
 
+    processed_dataset = convert_processed_dataset_by_task_type(
+        processed_dataset,
+        task_type=task_type,
+        n_pred_steps=n_pred_steps,
+        forecast_feature_indices=forecast_feature_indices,
+    )
+
     if rate > 0:
         if random_state is not None and "random_state" not in kwargs:
             kwargs["random_state"] = random_state
 
         # hold out ground truth in the original data for evaluation
-        train_X_ori = train_X
-        val_X_ori = val_X
-        test_X_ori = test_X
+        train_X_ori = processed_dataset["train_X"]
+        val_X_ori = processed_dataset["val_X"]
+        test_X_ori = processed_dataset["test_X"]
 
         # mask values in the train set to keep the same with below validation and test sets
-        train_X = create_missingness(train_X, rate, pattern, **kwargs)
+        train_X = create_missingness(processed_dataset["train_X"], rate, pattern, **kwargs)
         # mask values in the validation set as ground truth
-        val_X = create_missingness(val_X, rate, pattern, **kwargs)
+        val_X = create_missingness(processed_dataset["val_X"], rate, pattern, **kwargs)
         # mask values in the test set as ground truth
-        test_X = create_missingness(test_X, rate, pattern, **kwargs)
+        test_X = create_missingness(processed_dataset["test_X"], rate, pattern, **kwargs)
 
         processed_dataset["train_X"] = train_X
         processed_dataset["train_X_ori"] = train_X_ori
@@ -137,16 +144,5 @@ def preprocess_pems_traffic(
         processed_dataset["test_X_ori"] = test_X_ori
     else:
         logger.warning("rate is 0, no missing values are artificially added.")
-
-    processed_dataset = convert_processed_dataset_by_task_type(
-        processed_dataset,
-        task_type=task_type,
-        n_pred_steps=n_pred_steps,
-        forecast_feature_indices=forecast_feature_indices,
-    )
-    train_X = processed_dataset["train_X"]
-    val_X = processed_dataset["val_X"]
-    test_X = processed_dataset["test_X"]
-
-    print_final_dataset_info(train_X, val_X, test_X)
+    print_final_dataset_info(processed_dataset)
     return processed_dataset

--- a/benchpots/datasets/physionet_2012.py
+++ b/benchpots/datasets/physionet_2012.py
@@ -6,7 +6,7 @@ Preprocessing func for the dataset PhysionNet2012.
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause
 
-from typing import Optional
+from typing import Any, Optional, Sequence, Union
 
 import numpy as np
 import pandas as pd
@@ -20,15 +20,15 @@ from ..utils.task_type import convert_processed_dataset_by_task_type
 
 
 def preprocess_physionet2012(
-    subset,
-    rate,
+    subset: str,
+    rate: float,
     pattern: str = "point",
-    features: list = None,
+    features: Optional[list] = None,
     random_state: Optional[int] = None,
     task_type: str = "imputation",
     n_pred_steps: int = 1,
-    forecast_feature_indices=None,
-    **kwargs,
+    forecast_feature_indices: Optional[Union[int, Sequence[int]]] = None,
+    **kwargs: Any,
 ) -> dict:
     """Load and preprocess the dataset PhysionNet2012.
 
@@ -70,7 +70,7 @@ def preprocess_physionet2012(
 
     """
 
-    def apply_func(df_temp):  # pad and truncate to set the max length of samples as 48
+    def apply_func(df_temp: pd.DataFrame) -> pd.DataFrame:  # pad and truncate to set the max length of samples as 48
         missing = list(set(range(0, 48)).difference(set(df_temp["Time"])))
         missing_part = pd.DataFrame({"Time": missing})
         df_temp = pd.concat(
@@ -81,9 +81,7 @@ def preprocess_physionet2012(
         return df_temp
 
     all_subsets = ["all", "set-a", "set-b", "set-c"]
-    assert (
-        subset.lower() in all_subsets
-    ), f"subset should be one of {all_subsets}, but got {subset}"
+    assert subset.lower() in all_subsets, f"subset should be one of {all_subsets}, but got {subset}"
     assert 0 <= rate < 1, f"rate must be in [0, 1), but got {rate}"
 
     # read the raw data
@@ -104,9 +102,7 @@ def preprocess_physionet2012(
         y = pd.concat([data["outcomes-a"], data["outcomes-b"], data["outcomes-c"]])
         y = y.loc[unique_ids]
 
-    if (
-        features is None
-    ):  # if features are not specified, we use all features except the static features, e.g. age
+    if features is None:  # if features are not specified, we use all features except the static features, e.g. age
         X = X.drop(data["static_features"], axis=1)
     else:  # if features are specified by users, only use the specified features
         # check if the given features are valid
@@ -114,9 +110,7 @@ def preprocess_physionet2012(
         if not all_features.issuperset(features_set):
             intersection_feats = all_features.intersection(features_set)
             difference = features_set.difference(intersection_feats)
-            raise ValueError(
-                f"Given features contain invalid features that not in the dataset: {difference}"
-            )
+            raise ValueError(f"Given features contain invalid features that not in the dataset: {difference}")
         # check if the given features contain necessary features for preprocessing
         if "RecordID" not in features:
             features.append("RecordID")
@@ -224,6 +218,13 @@ def preprocess_physionet2012(
         "test_ICUType": test_ICUType.flatten(),
     }
 
+    processed_dataset = convert_processed_dataset_by_task_type(
+        processed_dataset,
+        task_type=task_type,
+        n_pred_steps=n_pred_steps,
+        forecast_feature_indices=forecast_feature_indices,
+    )
+
     if rate > 0:
         logger.warning(
             "Note that physionet_2012 has sparse observations in the time series, "
@@ -231,15 +232,13 @@ def preprocess_physionet2012(
         )
 
         # hold out ground truth in the original data for evaluation
-        val_X_ori = val_X
-        test_X_ori = test_X
+        val_X_ori = processed_dataset["val_X"]
+        test_X_ori = processed_dataset["test_X"]
 
         # mask values in the validation set as ground truth
-        val_X = create_missingness(val_X, rate, pattern, **kwargs)
+        val_X = create_missingness(processed_dataset["val_X"], rate, pattern, **kwargs)
         # mask values in the test set as ground truth
-        test_X = create_missingness(test_X, rate, pattern, **kwargs)
-
-        processed_dataset["train_X"] = train_X
+        test_X = create_missingness(processed_dataset["test_X"], rate, pattern, **kwargs)
 
         processed_dataset["val_X"] = val_X
         processed_dataset["val_X_ori"] = val_X_ori
@@ -259,16 +258,5 @@ def preprocess_physionet2012(
         )
     else:
         logger.warning("rate is 0, no missing values are artificially added.")
-
-    processed_dataset = convert_processed_dataset_by_task_type(
-        processed_dataset,
-        task_type=task_type,
-        n_pred_steps=n_pred_steps,
-        forecast_feature_indices=forecast_feature_indices,
-    )
-    train_X = processed_dataset["train_X"]
-    val_X = processed_dataset["val_X"]
-    test_X = processed_dataset["test_X"]
-
-    print_final_dataset_info(train_X, val_X, test_X)
+    print_final_dataset_info(processed_dataset)
     return processed_dataset

--- a/benchpots/datasets/physionet_2012.py
+++ b/benchpots/datasets/physionet_2012.py
@@ -6,6 +6,8 @@ Preprocessing func for the dataset PhysionNet2012.
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause
 
+from typing import Optional
+
 import numpy as np
 import pandas as pd
 import tsdb
@@ -22,6 +24,7 @@ def preprocess_physionet2012(
     rate,
     pattern: str = "point",
     features: list = None,
+    random_state: Optional[int] = None,
     task_type: str = "imputation",
     n_pred_steps: int = 1,
     forecast_feature_indices=None,
@@ -45,6 +48,10 @@ def preprocess_physionet2012(
     features:
         The features to be used in the dataset.
         If None, all features except the static features will be used.
+
+    random_state:
+        Controls the randomness of the train/validation/test split.
+        Pass an int for reproducible splits across runs.
 
     task_type:
         Task type for postprocessing. Supported values are
@@ -138,16 +145,16 @@ def preprocess_physionet2012(
 
     # split the dataset into the train, val, and test sets
     train_positive_set_ids, test_positive_set_ids = train_test_split(
-        positive_sample_IDs, test_size=0.2
+        positive_sample_IDs, test_size=0.2, random_state=random_state
     )
     train_positive_set_ids, val_positive_set_ids = train_test_split(
-        train_positive_set_ids, test_size=0.2
+        train_positive_set_ids, test_size=0.2, random_state=random_state
     )
     train_negative_set_ids, test_negative_set_ids = train_test_split(
-        negative_sample_IDs, test_size=0.2
+        negative_sample_IDs, test_size=0.2, random_state=random_state
     )
     train_negative_set_ids, val_negative_set_ids = train_test_split(
-        train_negative_set_ids, test_size=0.2
+        train_negative_set_ids, test_size=0.2, random_state=random_state
     )
     train_set_ids = np.concatenate([train_positive_set_ids, train_negative_set_ids])
     val_set_ids = np.concatenate([val_positive_set_ids, val_negative_set_ids])

--- a/benchpots/datasets/physionet_2019.py
+++ b/benchpots/datasets/physionet_2019.py
@@ -6,6 +6,8 @@ Preprocessing func for the dataset PhysioNet2019.
 # Created by Yiyuan Yang <yyy1997sjz@gmail.com> and Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause
 
+from typing import Optional
+
 import numpy as np
 import pandas as pd
 import tsdb
@@ -22,6 +24,7 @@ def preprocess_physionet2019(
     rate,
     pattern: str = "point",
     features: list = None,
+    random_state: Optional[int] = None,
     task_type: str = "imputation",
     n_pred_steps: int = 1,
     forecast_feature_indices=None,
@@ -45,6 +48,10 @@ def preprocess_physionet2019(
     features:
         The features to be used in the dataset.
         If None, all features except the static features will be used.
+
+    random_state:
+        Controls the randomness of the train/validation/test split.
+        Pass an int for reproducible splits across runs.
 
     task_type:
         Task type for postprocessing. Supported values are
@@ -128,8 +135,8 @@ def preprocess_physionet2019(
     # split the dataset into the train, val, and test sets
     # Cast to numpy array for sklearn compatibility when pandas returns extension arrays (e.g., pyarrow-backed).
     all_recordID = np.asarray(X["RecordID"].unique())
-    train_set_ids, test_set_ids = train_test_split(all_recordID, test_size=0.2)
-    train_set_ids, val_set_ids = train_test_split(train_set_ids, test_size=0.2)
+    train_set_ids, test_set_ids = train_test_split(all_recordID, test_size=0.2, random_state=random_state)
+    train_set_ids, val_set_ids = train_test_split(train_set_ids, test_size=0.2, random_state=random_state)
 
     train_set_ids.sort()
     val_set_ids.sort()

--- a/benchpots/datasets/physionet_2019.py
+++ b/benchpots/datasets/physionet_2019.py
@@ -6,7 +6,7 @@ Preprocessing func for the dataset PhysioNet2019.
 # Created by Yiyuan Yang <yyy1997sjz@gmail.com> and Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause
 
-from typing import Optional
+from typing import Any, Optional, Sequence, Union
 
 import numpy as np
 import pandas as pd
@@ -20,15 +20,15 @@ from ..utils.task_type import convert_processed_dataset_by_task_type
 
 
 def preprocess_physionet2019(
-    subset,
-    rate,
+    subset: str,
+    rate: float,
     pattern: str = "point",
-    features: list = None,
+    features: Optional[list] = None,
     random_state: Optional[int] = None,
     task_type: str = "imputation",
     n_pred_steps: int = 1,
-    forecast_feature_indices=None,
-    **kwargs,
+    forecast_feature_indices: Optional[Union[int, Sequence[int]]] = None,
+    **kwargs: Any,
 ) -> dict:
     """Load and preprocess the dataset PhysionNet2019.
 
@@ -70,7 +70,9 @@ def preprocess_physionet2019(
 
     """
 
-    def apply_func(df_temp):  # pad and truncate to set the max length of samples as 48
+    def apply_func(
+        df_temp: pd.DataFrame,
+    ) -> Optional[pd.DataFrame]:  # pad and truncate to set the max length of samples as 48
         if len(df_temp) < 48:
             return None
         else:
@@ -79,9 +81,7 @@ def preprocess_physionet2019(
         return df_temp
 
     all_subsets = ["all", "training_setA", "training_setB"]
-    assert (
-        subset in all_subsets
-    ), f"subset should be one of {all_subsets}, but got {subset}"
+    assert subset in all_subsets, f"subset should be one of {all_subsets}, but got {subset}"
     assert 0 <= rate < 1, f"rate must be in [0, 1), but got {rate}"
 
     # read the raw data
@@ -97,9 +97,7 @@ def preprocess_physionet2019(
         df = pd.concat([data["training_setA"], data["training_setB"]], sort=True)
         X = df.reset_index(drop=True)
 
-    if (
-        features is None
-    ):  # if features are not specified, we use all features except the static features, e.g. age
+    if features is None:  # if features are not specified, we use all features except the static features, e.g. age
         X = X.drop(data["static_features"], axis=1)
     else:  # if features are specified by users, only use the specified features
         # check if the given features are valid
@@ -107,9 +105,7 @@ def preprocess_physionet2019(
         if not all_features.issuperset(features_set):
             intersection_feats = all_features.intersection(features_set)
             difference = features_set.difference(intersection_feats)
-            raise ValueError(
-                f"Given features contain invalid features that not in the dataset: {difference}"
-            )
+            raise ValueError(f"Given features contain invalid features that not in the dataset: {difference}")
         # check if the given features contain necessary features for preprocessing
         if "RecordID" not in features:
             features.append("RecordID")
@@ -141,13 +137,9 @@ def preprocess_physionet2019(
     train_set_ids.sort()
     val_set_ids.sort()
     test_set_ids.sort()
-    train_set = X[X["RecordID"].isin(train_set_ids)].sort_values(
-        ["RecordID", time_feature]
-    )
+    train_set = X[X["RecordID"].isin(train_set_ids)].sort_values(["RecordID", time_feature])
     val_set = X[X["RecordID"].isin(val_set_ids)].sort_values(["RecordID", time_feature])
-    test_set = X[X["RecordID"].isin(test_set_ids)].sort_values(
-        ["RecordID", time_feature]
-    )
+    test_set = X[X["RecordID"].isin(test_set_ids)].sort_values(["RecordID", time_feature])
     train_y = train_set[[time_feature, label_feature]]
     val_y = val_set[[time_feature, label_feature]]
     test_y = test_set[[time_feature, label_feature]]
@@ -194,6 +186,13 @@ def preprocess_physionet2019(
         "test_y": test_y,
     }
 
+    processed_dataset = convert_processed_dataset_by_task_type(
+        processed_dataset,
+        task_type=task_type,
+        n_pred_steps=n_pred_steps,
+        forecast_feature_indices=forecast_feature_indices,
+    )
+
     if rate > 0:
         logger.warning(
             "Note that physionet_2019 has sparse observations in the time series, "
@@ -201,15 +200,13 @@ def preprocess_physionet2019(
         )
 
         # hold out ground truth in the original data for evaluation
-        val_X_ori = val_X
-        test_X_ori = test_X
+        val_X_ori = processed_dataset["val_X"]
+        test_X_ori = processed_dataset["test_X"]
 
         # mask values in the validation set as ground truth
-        val_X = create_missingness(val_X, rate, pattern, **kwargs)
+        val_X = create_missingness(processed_dataset["val_X"], rate, pattern, **kwargs)
         # mask values in the test set as ground truth
-        test_X = create_missingness(test_X, rate, pattern, **kwargs)
-
-        processed_dataset["train_X"] = train_X
+        test_X = create_missingness(processed_dataset["test_X"], rate, pattern, **kwargs)
 
         processed_dataset["val_X"] = val_X
         processed_dataset["val_X_ori"] = val_X_ori
@@ -225,16 +222,5 @@ def preprocess_physionet2019(
 
     else:
         logger.warning("rate is 0, no missing values are artificially added.")
-
-    processed_dataset = convert_processed_dataset_by_task_type(
-        processed_dataset,
-        task_type=task_type,
-        n_pred_steps=n_pred_steps,
-        forecast_feature_indices=forecast_feature_indices,
-    )
-    train_X = processed_dataset["train_X"]
-    val_X = processed_dataset["val_X"]
-    test_X = processed_dataset["test_X"]
-
-    print_final_dataset_info(train_X, val_X, test_X)
+    print_final_dataset_info(processed_dataset)
     return processed_dataset

--- a/benchpots/datasets/random_walk.py
+++ b/benchpots/datasets/random_walk.py
@@ -118,7 +118,7 @@ def gene_complete_random_walk_with_anomalies(
     n_total_steps = n_samples * n_steps
     X = seed.randn(n_total_steps, n_features) * std + mu
     n_anomaly = math.floor(n_total_steps * anomaly_rate)
-    anomaly_indices = np.random.choice(n_total_steps, size=n_anomaly, replace=False)
+    anomaly_indices = seed.choice(n_total_steps, size=n_anomaly, replace=False)
 
     flatten_X = X.flatten()
     min_val = flatten_X.min()
@@ -128,9 +128,9 @@ def gene_complete_random_walk_with_anomalies(
         anomaly_sample = X[a_i]
 
         # which feature to be anomaly
-        feat_idx = np.random.choice(a=n_features, size=1, replace=False)
+        feat_idx = seed.choice(a=n_features, size=1, replace=False)
 
-        anomaly_sample[feat_idx] = mu + np.random.uniform(
+        anomaly_sample[feat_idx] = mu + seed.uniform(
             low=min_val - anomaly_scale_factor * max_difference,
             high=max_val + anomaly_scale_factor * max_difference,
         )
@@ -145,7 +145,7 @@ def gene_complete_random_walk_with_anomalies(
 
     # shuffling
     indices = np.arange(n_samples)
-    np.random.shuffle(indices)
+    seed.shuffle(indices)
     X = X[indices]
     y = y[indices]
 
@@ -243,8 +243,9 @@ def gene_complete_random_walk_for_classification(
 
     # if shuffling, then shuffle the order of samples
     if shuffle:
+        rng = check_random_state(random_state)
         indices = np.arange(len(X))
-        np.random.shuffle(indices)
+        rng.shuffle(indices)
         X = X[indices]
         y = y[indices]
         anomaly_y = anomaly_y[indices] if len(anomaly_y) > 0 else anomaly_y
@@ -260,6 +261,7 @@ def preprocess_random_walk(
     anomaly_rate=0,
     missing_rate=0.1,
     pattern: str = "point",
+    random_state: Optional[int] = None,
     task_type: str = "imputation",
     n_pred_steps: int = 1,
     forecast_feature_indices=None,
@@ -292,6 +294,10 @@ def preprocess_random_walk(
         The missing pattern to apply to the dataset.
         Must be one of ['point', 'subseq', 'block'].
 
+    random_state:
+        Controls the randomness for generated samples and train/validation/test splits.
+        Pass an int for reproducible outputs across runs.
+
     task_type:
         Task type for postprocessing. Supported values are
         ['imputation', 'forecasting', 'classification', 'clustering', 'anomaly_detection'].
@@ -319,19 +325,20 @@ def preprocess_random_walk(
         n_steps=n_steps,
         n_features=n_features,
         anomaly_rate=anomaly_rate,
+        random_state=random_state,
     )
 
     # split into train/val/test sets
     if anomaly_rate > 0:
         train_X, test_X, train_y, test_y, train_anomaly_y, test_anomaly_y = train_test_split(
-            X, y, anomaly_y, test_size=0.2
+            X, y, anomaly_y, test_size=0.2, random_state=random_state
         )
         train_X, val_X, train_y, val_y, train_anomaly_y, val_anomaly_y = train_test_split(
-            train_X, train_y, train_anomaly_y, test_size=0.2
+            train_X, train_y, train_anomaly_y, test_size=0.2, random_state=random_state
         )
     else:
-        train_X, test_X, train_y, test_y = train_test_split(X, y, test_size=0.2)
-        train_X, val_X, train_y, val_y = train_test_split(train_X, train_y, test_size=0.2)
+        train_X, test_X, train_y, test_y = train_test_split(X, y, test_size=0.2, random_state=random_state)
+        train_X, val_X, train_y, val_y = train_test_split(train_X, train_y, test_size=0.2, random_state=random_state)
 
     if missing_rate > 0:
         # create random missing values

--- a/benchpots/datasets/random_walk.py
+++ b/benchpots/datasets/random_walk.py
@@ -8,7 +8,7 @@ Preprocessing func for the generated random walk dataset.
 
 
 import math
-from typing import Optional, Tuple
+from typing import Any, Optional, Sequence, Tuple, Union
 
 import numpy as np
 from pygrinder import mcar
@@ -254,18 +254,18 @@ def gene_complete_random_walk_for_classification(
 
 
 def preprocess_random_walk(
-    n_steps=24,
-    n_features=10,
-    n_classes=2,
-    n_samples_each_class=1000,
-    anomaly_rate=0,
-    missing_rate=0.1,
+    n_steps: int = 24,
+    n_features: int = 10,
+    n_classes: int = 2,
+    n_samples_each_class: int = 1000,
+    anomaly_rate: float = 0,
+    missing_rate: float = 0.1,
     pattern: str = "point",
     random_state: Optional[int] = None,
     task_type: str = "imputation",
     n_pred_steps: int = 1,
-    forecast_feature_indices=None,
-    **kwargs,
+    forecast_feature_indices: Optional[Union[int, Sequence[int]]] = None,
+    **kwargs: Any,
 ) -> dict:
     """Generate a random-walk data.
 
@@ -358,6 +358,10 @@ def preprocess_random_walk(
     train_X = train_X.reshape(-1, n_steps, n_features)
     val_X = val_X.reshape(-1, n_steps, n_features)
     test_X = test_X.reshape(-1, n_steps, n_features)
+
+    if missing_rate > 0:
+        train_X_ori = scaler.transform(train_X_ori.reshape(-1, n_features)).reshape(-1, n_steps, n_features)
+
     processed_dataset = {
         # general info
         "n_classes": n_classes,
@@ -382,27 +386,9 @@ def preprocess_random_walk(
 
     if missing_rate > 0:
         # hold out ground truth in the original data for evaluation
-        train_X_ori = scaler.transform(train_X_ori.reshape(-1, n_features)).reshape(-1, n_steps, n_features)
-        val_X_ori = val_X
-        test_X_ori = test_X
-
-        # mask values in the train set to keep the same with below validation and test sets
-        train_X = create_missingness(train_X, missing_rate, pattern, **kwargs)
-        # mask values in the validation set as ground truth
-        val_X = create_missingness(val_X, missing_rate, pattern, **kwargs)
-        # mask values in the test set as ground truth
-        test_X = create_missingness(test_X, missing_rate, pattern, **kwargs)
-
-        processed_dataset["train_X"] = train_X
         processed_dataset["train_X_ori"] = train_X_ori
-
-        processed_dataset["val_X"] = val_X
-        processed_dataset["val_X_ori"] = val_X_ori
-
-        processed_dataset["test_X"] = test_X
-        processed_dataset["test_X_ori"] = test_X_ori
-    else:
-        logger.warning("rate is 0, no missing values are artificially added.")
+        processed_dataset["val_X_ori"] = val_X
+        processed_dataset["test_X_ori"] = test_X
 
     processed_dataset = convert_processed_dataset_by_task_type(
         processed_dataset,
@@ -410,9 +396,21 @@ def preprocess_random_walk(
         n_pred_steps=n_pred_steps,
         forecast_feature_indices=forecast_feature_indices,
     )
-    train_X = processed_dataset["train_X"]
-    val_X = processed_dataset["val_X"]
-    test_X = processed_dataset["test_X"]
 
-    print_final_dataset_info(train_X, val_X, test_X)
+    if missing_rate > 0:
+        # mask values in the train set to keep the same with below validation and test sets
+        train_X = create_missingness(processed_dataset["train_X"], missing_rate, pattern, **kwargs)
+        # mask values in the validation set as ground truth
+        val_X = create_missingness(processed_dataset["val_X"], missing_rate, pattern, **kwargs)
+        # mask values in the test set as ground truth
+        test_X = create_missingness(processed_dataset["test_X"], missing_rate, pattern, **kwargs)
+
+        processed_dataset["train_X"] = train_X
+
+        processed_dataset["val_X"] = val_X
+
+        processed_dataset["test_X"] = test_X
+    else:
+        logger.warning("rate is 0, no missing values are artificially added.")
+    print_final_dataset_info(processed_dataset)
     return processed_dataset

--- a/benchpots/datasets/solar_alabama.py
+++ b/benchpots/datasets/solar_alabama.py
@@ -6,6 +6,8 @@ Preprocessing func for the dataset Solar Alabama.
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause
 
+from typing import Optional
+
 import pandas as pd
 import tsdb
 from sklearn.preprocessing import StandardScaler
@@ -20,6 +22,7 @@ def preprocess_solar_alabama(
     rate,
     n_steps,
     pattern: str = "point",
+    random_state: Optional[int] = None,
     task_type: str = "imputation",
     n_pred_steps: int = 1,
     forecast_feature_indices=None,
@@ -39,6 +42,10 @@ def preprocess_solar_alabama(
     pattern:
         The missing pattern to apply to the dataset.
         Must be one of ['point', 'subseq', 'block'].
+
+    random_state:
+        Controls the randomness of missingness generation.
+        Pass an int for reproducible missingness masks across runs.
 
     task_type:
         Task type for postprocessing. Supported values are
@@ -103,6 +110,9 @@ def preprocess_solar_alabama(
     }
 
     if rate > 0:
+        if random_state is not None and "random_state" not in kwargs:
+            kwargs["random_state"] = random_state
+
         # hold out ground truth in the original data for evaluation
         train_X_ori = train_X
         val_X_ori = val_X

--- a/benchpots/datasets/solar_alabama.py
+++ b/benchpots/datasets/solar_alabama.py
@@ -6,7 +6,7 @@ Preprocessing func for the dataset Solar Alabama.
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause
 
-from typing import Optional
+from typing import Any, Optional, Sequence, Union
 
 import pandas as pd
 import tsdb
@@ -19,14 +19,14 @@ from ..utils.task_type import convert_processed_dataset_by_task_type
 
 
 def preprocess_solar_alabama(
-    rate,
-    n_steps,
+    rate: float,
+    n_steps: int,
     pattern: str = "point",
     random_state: Optional[int] = None,
     task_type: str = "imputation",
     n_pred_steps: int = 1,
-    forecast_feature_indices=None,
-    **kwargs,
+    forecast_feature_indices: Optional[Union[int, Sequence[int]]] = None,
+    **kwargs: Any,
 ) -> dict:
     """Load and preprocess the dataset Solar Alabama.
 
@@ -109,21 +109,28 @@ def preprocess_solar_alabama(
         "test_X": test_X,
     }
 
+    processed_dataset = convert_processed_dataset_by_task_type(
+        processed_dataset,
+        task_type=task_type,
+        n_pred_steps=n_pred_steps,
+        forecast_feature_indices=forecast_feature_indices,
+    )
+
     if rate > 0:
         if random_state is not None and "random_state" not in kwargs:
             kwargs["random_state"] = random_state
 
         # hold out ground truth in the original data for evaluation
-        train_X_ori = train_X
-        val_X_ori = val_X
-        test_X_ori = test_X
+        train_X_ori = processed_dataset["train_X"]
+        val_X_ori = processed_dataset["val_X"]
+        test_X_ori = processed_dataset["test_X"]
 
         # mask values in the train set to keep the same with below validation and test sets
-        train_X = create_missingness(train_X, rate, pattern, **kwargs)
+        train_X = create_missingness(processed_dataset["train_X"], rate, pattern, **kwargs)
         # mask values in the validation set as ground truth
-        val_X = create_missingness(val_X, rate, pattern, **kwargs)
+        val_X = create_missingness(processed_dataset["val_X"], rate, pattern, **kwargs)
         # mask values in the test set as ground truth
-        test_X = create_missingness(test_X, rate, pattern, **kwargs)
+        test_X = create_missingness(processed_dataset["test_X"], rate, pattern, **kwargs)
 
         processed_dataset["train_X"] = train_X
         processed_dataset["train_X_ori"] = train_X_ori
@@ -135,16 +142,5 @@ def preprocess_solar_alabama(
         processed_dataset["test_X_ori"] = test_X_ori
     else:
         logger.warning("rate is 0, no missing values are artificially added.")
-
-    processed_dataset = convert_processed_dataset_by_task_type(
-        processed_dataset,
-        task_type=task_type,
-        n_pred_steps=n_pred_steps,
-        forecast_feature_indices=forecast_feature_indices,
-    )
-    train_X = processed_dataset["train_X"]
-    val_X = processed_dataset["val_X"]
-    test_X = processed_dataset["test_X"]
-
-    print_final_dataset_info(train_X, val_X, test_X)
+    print_final_dataset_info(processed_dataset)
     return processed_dataset

--- a/benchpots/datasets/ucr_uea_datasets.py
+++ b/benchpots/datasets/ucr_uea_datasets.py
@@ -6,7 +6,7 @@ Preprocessing func for the UCR&UAE datasets.
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause
 
-from typing import Optional
+from typing import Any, Optional, Sequence, Union
 
 import tsdb
 from pandas.api.types import is_string_dtype
@@ -19,14 +19,14 @@ from ..utils.task_type import convert_processed_dataset_by_task_type
 
 
 def preprocess_ucr_uea_datasets(
-    dataset_name,
-    rate,
+    dataset_name: str,
+    rate: float,
     pattern: str = "point",
     random_state: Optional[int] = None,
     task_type: str = "imputation",
     n_pred_steps: int = 1,
-    forecast_feature_indices=None,
-    **kwargs,
+    forecast_feature_indices: Optional[Union[int, Sequence[int]]] = None,
+    **kwargs: Any,
 ) -> dict:
     """Load and preprocess the dataset from UCR&UEA.
 
@@ -65,9 +65,7 @@ def preprocess_ucr_uea_datasets(
     """
 
     assert 0 <= rate < 1, f"rate must be in [0, 1), but got {rate}"
-    assert dataset_name.startswith(
-        "ucr_uea_"
-    ), f"set_name must start with 'ucr_uea_', but got {dataset_name}"
+    assert dataset_name.startswith("ucr_uea_"), f"set_name must start with 'ucr_uea_', but got {dataset_name}"
     assert dataset_name in tsdb.list(), f"{dataset_name} is not in TSDB database."
 
     data = tsdb.load(dataset_name)
@@ -124,18 +122,25 @@ def preprocess_ucr_uea_datasets(
     if le is not None:
         processed_dataset["label_encoder"] = le
 
+    processed_dataset = convert_processed_dataset_by_task_type(
+        processed_dataset,
+        task_type=task_type,
+        n_pred_steps=n_pred_steps,
+        forecast_feature_indices=forecast_feature_indices,
+    )
+
     if rate > 0:
         # hold out ground truth in the original data for evaluation
-        train_X_ori = train_X
-        val_X_ori = val_X
-        test_X_ori = test_X
+        train_X_ori = processed_dataset["train_X"]
+        val_X_ori = processed_dataset["val_X"]
+        test_X_ori = processed_dataset["test_X"]
 
         # mask values in the train set to keep the same with below validation and test sets
-        train_X = create_missingness(train_X, rate, pattern, **kwargs)
+        train_X = create_missingness(processed_dataset["train_X"], rate, pattern, **kwargs)
         # mask values in the validation set as ground truth
-        val_X = create_missingness(val_X, rate, pattern, **kwargs)
+        val_X = create_missingness(processed_dataset["val_X"], rate, pattern, **kwargs)
         # mask values in the test set as ground truth
-        test_X = create_missingness(test_X, rate, pattern, **kwargs)
+        test_X = create_missingness(processed_dataset["test_X"], rate, pattern, **kwargs)
 
         processed_dataset["train_X"] = train_X
         processed_dataset["train_X_ori"] = train_X_ori
@@ -147,16 +152,5 @@ def preprocess_ucr_uea_datasets(
         processed_dataset["test_X_ori"] = test_X_ori
     else:
         logger.warning("rate is 0, no missing values are artificially added.")
-
-    processed_dataset = convert_processed_dataset_by_task_type(
-        processed_dataset,
-        task_type=task_type,
-        n_pred_steps=n_pred_steps,
-        forecast_feature_indices=forecast_feature_indices,
-    )
-    train_X = processed_dataset["train_X"]
-    val_X = processed_dataset["val_X"]
-    test_X = processed_dataset["test_X"]
-
-    print_final_dataset_info(train_X, val_X, test_X)
+    print_final_dataset_info(processed_dataset)
     return processed_dataset

--- a/benchpots/datasets/ucr_uea_datasets.py
+++ b/benchpots/datasets/ucr_uea_datasets.py
@@ -6,6 +6,8 @@ Preprocessing func for the UCR&UAE datasets.
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause
 
+from typing import Optional
+
 import tsdb
 from pandas.api.types import is_string_dtype
 from sklearn.model_selection import train_test_split
@@ -20,6 +22,7 @@ def preprocess_ucr_uea_datasets(
     dataset_name,
     rate,
     pattern: str = "point",
+    random_state: Optional[int] = None,
     task_type: str = "imputation",
     n_pred_steps: int = 1,
     forecast_feature_indices=None,
@@ -39,6 +42,10 @@ def preprocess_ucr_uea_datasets(
     pattern:
         The missing pattern to apply to the dataset.
         Must be one of ['point', 'subseq', 'block'].
+
+    random_state:
+        Controls the randomness of the train/validation split.
+        Pass an int for reproducible splits across runs.
 
     task_type:
         Task type for postprocessing. Supported values are
@@ -77,7 +84,7 @@ def preprocess_ucr_uea_datasets(
 
     n_X_train = len(X_train)
 
-    train_ids, val_ids = train_test_split(list(range(n_X_train)), test_size=0.2)
+    train_ids, val_ids = train_test_split(list(range(n_X_train)), test_size=0.2, random_state=random_state)
     X_train, X_val = X_train[train_ids], X_train[val_ids]
     y_train, y_val = y_train[train_ids], y_train[val_ids]
 

--- a/benchpots/utils/__init__.py
+++ b/benchpots/utils/__init__.py
@@ -1,6 +1,4 @@
-"""
-
-"""
+""" """
 
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause

--- a/benchpots/utils/logging.py
+++ b/benchpots/utils/logging.py
@@ -7,7 +7,6 @@ Configure logging here.
 
 from pygrinder import calc_missing_rate
 from tsdb.utils.logging import Logger
-from typing import Any
 
 # initialize a logger for PyPOTS logging
 logger_creator = Logger(name="BenchPOTS running log")

--- a/benchpots/utils/logging.py
+++ b/benchpots/utils/logging.py
@@ -5,6 +5,8 @@ Configure logging here.
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause
 
+from typing import Any
+
 from pygrinder import calc_missing_rate
 from tsdb.utils.logging import Logger
 
@@ -13,21 +15,45 @@ logger_creator = Logger(name="BenchPOTS running log")
 logger = logger_creator.logger
 
 
-def print_final_dataset_info(train_X, val_X, test_X):
+def print_final_dataset_info(
+    processed_dataset: dict,
+) -> None:
+    train_X = processed_dataset["train_X"]
+    val_X = processed_dataset["val_X"]
+    test_X = processed_dataset["test_X"]
+
     train_set_size, val_set_size, test_set_size = len(train_X), len(val_X), len(test_X)
     total_size = len(train_X) + len(val_X) + len(test_X)
     n_steps, n_features = train_X.shape[1], train_X.shape[2]
 
     logger.info(f"Total sample number: {total_size}")
-    logger.info(
-        f"Training set size: {train_set_size} ({train_set_size / total_size:.2%})"
-    )
-    logger.info(
-        f"Validation set size: {val_set_size} ({val_set_size / total_size:.2%})"
-    )
+    logger.info(f"Training set size: {train_set_size} ({train_set_size / total_size:.2%})")
+    logger.info(f"Validation set size: {val_set_size} ({val_set_size / total_size:.2%})")
     logger.info(f"Test set size: {test_set_size} ({test_set_size / total_size:.2%})")
     logger.info(f"Number of steps: {n_steps}")
     logger.info(f"Number of features: {n_features}")
     logger.info(f"Train set missing rate: {calc_missing_rate(train_X):.2%}")
     logger.info(f"Validating set missing rate: {calc_missing_rate(val_X):.2%}")
     logger.info(f"Test set missing rate: {calc_missing_rate(test_X):.2%}")
+
+    if processed_dataset.get("task_type", "imputation") == "forecasting":
+        logger.info("Task type: forecasting")
+        if processed_dataset.get("n_steps_original") is not None:
+            logger.info(f"Original number of steps: {processed_dataset['n_steps_original']}")
+        if processed_dataset.get("n_pred_steps") is not None:
+            logger.info(f"Number of prediction steps: {processed_dataset['n_pred_steps']}")
+        if processed_dataset.get("n_pred_features") is not None:
+            logger.info(f"Number of prediction features: {processed_dataset['n_pred_features']}")
+
+        if processed_dataset.get("train_X_pred") is not None:
+            logger.info(
+                f"Train prediction target missing rate: {calc_missing_rate(processed_dataset['train_X_pred']):.2%}"
+            )
+        if processed_dataset.get("val_X_pred") is not None:
+            logger.info(
+                f"Validation prediction target missing rate: {calc_missing_rate(processed_dataset['val_X_pred']):.2%}"
+            )
+        if processed_dataset.get("test_X_pred") is not None:
+            logger.info(
+                f"Test prediction target missing rate: {calc_missing_rate(processed_dataset['test_X_pred']):.2%}"
+            )

--- a/benchpots/utils/logging.py
+++ b/benchpots/utils/logging.py
@@ -5,10 +5,9 @@ Configure logging here.
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause
 
-from typing import Any
-
 from pygrinder import calc_missing_rate
 from tsdb.utils.logging import Logger
+from typing import Any
 
 # initialize a logger for PyPOTS logging
 logger_creator = Logger(name="BenchPOTS running log")

--- a/benchpots/utils/missingness.py
+++ b/benchpots/utils/missingness.py
@@ -1,15 +1,14 @@
-"""
-
-"""
+""" """
 
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause
 
 
 from pygrinder import mcar, seq_missing, block_missing
+from typing import Any
 
 
-def create_missingness(X, rate, pattern, **kwargs):
+def create_missingness(X: Any, rate: float, pattern: str, **kwargs: Any) -> Any:
     """Create missingness in the data.
 
     Parameters

--- a/benchpots/utils/sliding.py
+++ b/benchpots/utils/sliding.py
@@ -55,9 +55,7 @@ def sliding_window(
         f"time_series length {len(time_series)} is less than "
         f"window_size {window_size}. There is no space for sliding."
     )
-    assert (
-        stride > 0 and window_size > 0
-    ), f"stride {stride} and window_size {window_size} must be positive"
+    assert stride > 0 and window_size > 0, f"stride {stride} and window_size {window_size} must be positive"
     assert stride <= window_size, (
         f"stride {stride} shouldn't be larger than window_size {window_size}. "
         f"Otherwise there will be gaps between samples."
@@ -88,15 +86,13 @@ def sliding_window(
         raise RuntimeError
 
     if not drop_last:
-        logger.info(
-            "drop_last is set as False, the last sample is kept and will be returned independently."
-        )
+        logger.info("drop_last is set as False, the last sample is kept and will be returned independently.")
         return samples, time_series[start_indices[-1] + stride :]
 
     return samples
 
 
-def inverse_sliding_window(X, stride):
+def inverse_sliding_window(X: Union[np.ndarray, torch.Tensor], stride: int) -> Union[np.ndarray, torch.Tensor]:
     """Restore the original time-series data from the generated sliding window samples.
     Note that this is the inverse operation of the `sliding_window` function, but there is no guarantee that
     the restored data is the same as the original data considering that

--- a/benchpots/utils/task_type.py
+++ b/benchpots/utils/task_type.py
@@ -73,6 +73,7 @@ def convert_processed_dataset_by_task_type(
     processed_dataset["task_type"] = task_type
 
     if task_type != "forecasting":
+        # so far other tasks do not need further processing steps
         return processed_dataset
 
     if not isinstance(n_pred_steps, int) or n_pred_steps <= 0:

--- a/benchpots/version.py
+++ b/benchpots/version.py
@@ -1,6 +1,4 @@
-"""
-
-"""
+""" """
 
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,4 @@
-"""
-
-"""
+""" """
 
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause

--- a/tests/test_benchpots.py
+++ b/tests/test_benchpots.py
@@ -7,8 +7,11 @@
 
 
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import numpy as np
+import pandas as pd
 import torch
 from pygrinder import calc_missing_rate
 
@@ -18,8 +21,10 @@ from benchpots.datasets import (
     preprocess_physionet2019,
     preprocess_ett,
     preprocess_electricity_load_diagrams,
+    preprocess_pems_traffic,
     preprocess_beijing_air_quality,
     preprocess_italy_air_quality,
+    preprocess_solar_alabama,
     preprocess_ucr_uea_datasets,
     preprocess_nl_benchmarks,
 )
@@ -28,6 +33,121 @@ from benchpots.utils import convert_processed_dataset_by_task_type
 
 
 class TestBenchPOTS(unittest.TestCase):
+    @staticmethod
+    def _build_mock_physionet2012_data(n_records=20):
+        record_ids = np.arange(1000, 1000 + n_records)
+        rows = []
+        for record_id in record_ids:
+            for time in range(48):
+                rows.append(
+                    {
+                        "RecordID": record_id,
+                        "Time": time,
+                        "ICUType": (record_id % 4) + 1,
+                        "Age": 40 + (record_id % 10),
+                        "HR": float(record_id + time),
+                    }
+                )
+
+        set_a = pd.DataFrame(rows)
+        n_positive = n_records // 2
+        n_negative = n_records - n_positive
+        outcomes_a = pd.DataFrame(
+            {"In-hospital_death": [1] * n_positive + [0] * n_negative},
+            index=record_ids,
+        )
+        return {
+            "set-a": set_a,
+            "outcomes-a": outcomes_a,
+            "static_features": ["Age", "ICUType"],
+        }
+
+    @staticmethod
+    def _build_mock_physionet2019_data(n_records=20):
+        record_ids = np.arange(2000, 2000 + n_records)
+        rows = []
+        for record_id in record_ids:
+            for iculos in range(1, 49):
+                rows.append(
+                    {
+                        "RecordID": record_id,
+                        "ICULOS": iculos,
+                        "SepsisLabel": int(record_id % 2),
+                        "Age": 50 + (record_id % 10),
+                        "HR": float(record_id + iculos),
+                    }
+                )
+
+        training_set_a = pd.DataFrame(rows)
+        return {
+            "training_setA": training_set_a,
+            "training_setB": training_set_a.copy(),
+            "static_features": ["Age"],
+        }
+
+    @staticmethod
+    def _build_mock_ucr_uea_data(n_train=20, n_test=8, n_steps=6, n_features=2):
+        X_train = np.repeat(np.arange(n_train, dtype=float).reshape(-1, 1, 1), n_steps * n_features, axis=2).reshape(
+            n_train, n_steps, n_features
+        )
+        X_test = np.repeat(np.arange(n_test, dtype=float).reshape(-1, 1, 1), n_steps * n_features, axis=2).reshape(
+            n_test, n_steps, n_features
+        )
+        y_train = np.arange(n_train)
+        y_test = np.arange(n_test)
+        return {"X_train": X_train, "y_train": y_train, "X_test": X_test, "y_test": y_test}
+
+    @staticmethod
+    def _build_mock_monthly_df_with_index(n_months=24):
+        dates = pd.date_range("2010-01-01", periods=n_months, freq="MS")
+        return pd.DataFrame({"feat": np.arange(n_months, dtype=float)}, index=dates)
+
+    @staticmethod
+    def _build_mock_monthly_df_with_date_col(n_months=24):
+        dates = pd.date_range("2010-01-01", periods=n_months, freq="MS")
+        return pd.DataFrame({"date": dates, "feat": np.arange(n_months, dtype=float)})
+
+    @staticmethod
+    def _build_mock_beijing_data(n_months=40):
+        dates = pd.date_range("2010-01-01", periods=n_months, freq="MS")
+        rows = []
+        for i, date in enumerate(dates):
+            rows.append(
+                {
+                    "year": date.year,
+                    "month": date.month,
+                    "day": date.day,
+                    "hour": 0,
+                    "station": "A",
+                    "wd": "N",
+                    "No": i,
+                    "PM2.5": float(i),
+                }
+            )
+        return {"X": pd.DataFrame(rows)}
+
+    @staticmethod
+    def _build_mock_italy_data(n_rows=60):
+        return {
+            "X": pd.DataFrame(
+                {
+                    "Date": ["01/01/2010"] * n_rows,
+                    "Time": [f"{i % 24:02d}.00.00" for i in range(n_rows)],
+                    "CO(GT)": np.linspace(0.0, 1.0, n_rows),
+                    "NOx(GT)": np.linspace(1.0, 2.0, n_rows),
+                }
+            )
+        }
+
+    @staticmethod
+    def _build_mock_nl_sequence(n_rows=80):
+        return SimpleNamespace(
+            u=np.linspace(0.0, 1.0, n_rows).reshape(-1, 1),
+            y=np.linspace(1.0, 2.0, n_rows).reshape(-1, 1),
+            sampling_time=0.1,
+            state_initialization_window_length=10,
+        )
+
     def test_random_walk(self):
         n_steps = 8
         n_features = 5
@@ -69,6 +189,135 @@ class TestBenchPOTS(unittest.TestCase):
 
     def test_physionet2012(self):
         preprocess_physionet2012(subset="set-a", rate=0.1)
+
+    def test_ucr_uea_split_random_state(self):
+        with patch("benchpots.datasets.ucr_uea_datasets.tsdb.list", return_value=["ucr_uea_mock"]), patch(
+            "benchpots.datasets.ucr_uea_datasets.tsdb.load",
+            side_effect=lambda _: self._build_mock_ucr_uea_data(),
+        ):
+            ds_a = preprocess_ucr_uea_datasets(dataset_name="ucr_uea_mock", rate=0, random_state=42)
+            ds_b = preprocess_ucr_uea_datasets(dataset_name="ucr_uea_mock", rate=0, random_state=42)
+            ds_c = preprocess_ucr_uea_datasets(dataset_name="ucr_uea_mock", rate=0, random_state=7)
+
+        np.testing.assert_array_equal(ds_a["train_y"], ds_b["train_y"])
+        np.testing.assert_array_equal(ds_a["val_y"], ds_b["val_y"])
+        np.testing.assert_array_equal(ds_a["test_y"], ds_b["test_y"])
+        np.testing.assert_array_equal(ds_a["test_y"], ds_c["test_y"])
+        split_changed = not np.array_equal(ds_a["train_y"], ds_c["train_y"]) or not np.array_equal(
+            ds_a["val_y"], ds_c["val_y"]
+        )
+        assert split_changed, "Different random_state values should produce different splits."
+
+    def test_remaining_preprocessors_forward_random_state_to_missingness(self):
+        random_state = 123
+
+        with patch(
+            "benchpots.datasets.beijing_multisite_air_quality.tsdb.load",
+            return_value=self._build_mock_beijing_data(),
+        ), patch(
+            "benchpots.datasets.beijing_multisite_air_quality.create_missingness",
+            side_effect=lambda X, rate, pattern, **kwargs: X,
+        ) as mock_missing:
+            preprocess_beijing_air_quality(rate=0.1, n_steps=1, random_state=random_state)
+            assert len(mock_missing.call_args_list) == 3
+            assert all(call.kwargs.get("random_state") == random_state for call in mock_missing.call_args_list)
+
+        with patch(
+            "benchpots.datasets.electricity_load_diagrams.tsdb.load",
+            return_value={"X": self._build_mock_monthly_df_with_index(n_months=24)},
+        ), patch(
+            "benchpots.datasets.electricity_load_diagrams.create_missingness",
+            side_effect=lambda X, rate, pattern, **kwargs: X,
+        ) as mock_missing:
+            preprocess_electricity_load_diagrams(rate=0.1, n_steps=1, random_state=random_state)
+            assert len(mock_missing.call_args_list) == 3
+            assert all(call.kwargs.get("random_state") == random_state for call in mock_missing.call_args_list)
+
+        with patch(
+            "benchpots.datasets.electricity_transformer_temperature.tsdb.load",
+            return_value={"ETTh1": self._build_mock_monthly_df_with_index(n_months=24)},
+        ), patch(
+            "benchpots.datasets.electricity_transformer_temperature.create_missingness",
+            side_effect=lambda X, rate, pattern, **kwargs: X,
+        ) as mock_missing:
+            preprocess_ett(subset="ETTh1", rate=0.1, n_steps=1, random_state=random_state)
+            assert len(mock_missing.call_args_list) == 3
+            assert all(call.kwargs.get("random_state") == random_state for call in mock_missing.call_args_list)
+
+        with patch(
+            "benchpots.datasets.italy_air_quality.tsdb.load",
+            return_value=self._build_mock_italy_data(),
+        ), patch(
+            "benchpots.datasets.italy_air_quality.create_missingness",
+            side_effect=lambda X, rate, pattern, **kwargs: X,
+        ) as mock_missing:
+            preprocess_italy_air_quality(rate=0.1, n_steps=1, random_state=random_state)
+            assert len(mock_missing.call_args_list) == 3
+            assert all(call.kwargs.get("random_state") == random_state for call in mock_missing.call_args_list)
+
+        with patch(
+            "benchpots.datasets.pems_traffic.tsdb.load",
+            return_value={"X": self._build_mock_monthly_df_with_date_col(n_months=24)},
+        ), patch(
+            "benchpots.datasets.pems_traffic.create_missingness",
+            side_effect=lambda X, rate, pattern, **kwargs: X,
+        ) as mock_missing:
+            preprocess_pems_traffic(rate=0.1, n_steps=1, random_state=random_state)
+            assert len(mock_missing.call_args_list) == 3
+            assert all(call.kwargs.get("random_state") == random_state for call in mock_missing.call_args_list)
+
+        with patch(
+            "benchpots.datasets.solar_alabama.tsdb.load",
+            return_value={"X": self._build_mock_monthly_df_with_date_col(n_months=12)},
+        ), patch(
+            "benchpots.datasets.solar_alabama.create_missingness",
+            side_effect=lambda X, rate, pattern, **kwargs: X,
+        ) as mock_missing:
+            preprocess_solar_alabama(rate=0.1, n_steps=1, random_state=random_state)
+            assert len(mock_missing.call_args_list) == 3
+            assert all(call.kwargs.get("random_state") == random_state for call in mock_missing.call_args_list)
+
+        with patch(
+            "benchpots.datasets.nl_benchmarks.nonlinear_benchmarks.EMPS",
+            return_value=(self._build_mock_nl_sequence(), self._build_mock_nl_sequence()),
+        ), patch(
+            "benchpots.datasets.nl_benchmarks.create_missingness",
+            side_effect=lambda X, rate, pattern, **kwargs: X,
+        ) as mock_missing:
+            preprocess_nl_benchmarks(dataset_name="EMPS", rate=0.1, n_steps=1, random_state=random_state)
+            assert len(mock_missing.call_args_list) == 3
+            assert all(call.kwargs.get("random_state") == random_state for call in mock_missing.call_args_list)
+
+    def test_random_walk_split_random_state(self):
+        ds_a = preprocess_random_walk(
+            n_steps=8,
+            n_features=3,
+            n_classes=3,
+            n_samples_each_class=40,
+            missing_rate=0,
+            random_state=42,
+        )
+        ds_b = preprocess_random_walk(
+            n_steps=8,
+            n_features=3,
+            n_classes=3,
+            n_samples_each_class=40,
+            missing_rate=0,
+            random_state=42,
+        )
+        ds_c = preprocess_random_walk(
+            n_steps=8,
+            n_features=3,
+            n_classes=3,
+            n_samples_each_class=40,
+            missing_rate=0,
+            random_state=7,
+        )
+
+        np.testing.assert_allclose(ds_a["train_X"], ds_b["train_X"])
+        np.testing.assert_array_equal(ds_a["train_y"], ds_b["train_y"])
+        split_changed = not np.allclose(ds_a["train_X"], ds_c["train_X"])
+        assert split_changed, "Different random_state values should produce different splits."
 
     def test_random_walk_forecasting_shapes(self):
         n_steps = 12

--- a/tests/test_benchpots.py
+++ b/tests/test_benchpots.py
@@ -1,6 +1,4 @@
-"""
-
-"""
+""" """
 
 # Created by Wenjie Du <wenjay.du@gmail.com>
 # License: BSD-3-Clause
@@ -372,6 +370,22 @@ class TestBenchPOTS(unittest.TestCase):
         np.testing.assert_allclose(converted["train_X_pred"], (base_X + 100)[:, -n_pred_steps:, :], equal_nan=True)
         np.testing.assert_allclose(converted["val_X_pred"], (base_X + 110)[:, -n_pred_steps:, :], equal_nan=True)
         np.testing.assert_allclose(converted["test_X_pred"], (base_X + 120)[:, -n_pred_steps:, :], equal_nan=True)
+
+    def test_random_walk_forecasting_prediction_targets_have_no_artificial_missing(self):
+        dataset = preprocess_random_walk(
+            n_steps=12,
+            n_features=3,
+            n_classes=2,
+            n_samples_each_class=60,
+            missing_rate=0.2,
+            task_type="forecasting",
+            n_pred_steps=3,
+            random_state=42,
+        )
+
+        assert not np.isnan(dataset["train_X_pred"]).any()
+        assert not np.isnan(dataset["val_X_pred"]).any()
+        assert not np.isnan(dataset["test_X_pred"]).any()
 
     def test_task_type_conversion_validation(self):
         fake_dataset = {


### PR DESCRIPTION
<!-- 🚨Please create your PR to merge code from your branch to `dev` branch here, rather than `main`. -->

# What does this PR do?

<!--
Congrats! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution 😉.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, I will review your PR shortly. I may suggest changes to make the code even better 🤝.
-->

<!-- Remove if not applicable -->

The current preprocessing functions add missing values first then truncate the series to reserve the forecasting steps. But this may result in the mismatch between the arg `rate` and the actual missing rate of output data. We actually need to reserve the forecasting steps first then add artificially missing values.



## Before submitting

<!-- You can remove checks that are not relevant to this PR. -->

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have written necessary tests and already run them locally.
